### PR TITLE
Make sure MinMaxCloseControl supports fullscreen and tablet mode

### DIFF
--- a/.github/actions/spell-check/expect/expect.txt
+++ b/.github/actions/spell-check/expect/expect.txt
@@ -377,6 +377,7 @@ coord
 coordnew
 COPYCOLOR
 CORESYSTEM
+corewrappers
 cotaskmem
 countof
 cout
@@ -2519,6 +2520,7 @@ VFT
 vga
 vgaoem
 viewkind
+viewmanagement
 viewports
 Virt
 VIRTTERM
@@ -2526,6 +2528,7 @@ Virtualizing
 vk
 vkey
 VKKEYSCAN
+vm
 VMs
 VPA
 VPATH

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.cpp
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.cpp
@@ -79,6 +79,13 @@ namespace winrt::TerminalApp::implementation
             CloseButton().Height(maximizedHeight);
             break;
 
+
+        case WindowVisualState::WindowVisualStateTablet:
+           VisualStateManager::GoToState(MaximizeButton(), L"WindowStateTablet", false);
+           VisualStateManager::GoToState(MinimizeButton(), L"WindowStateTablet", false);
+            VisualStateManager::GoToState(CloseButton(), L"WindowStateTablet", false);
+            break;
+
         case WindowVisualState::WindowVisualStateNormal:
         case WindowVisualState::WindowVisualStateIconified:
         default:

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -127,6 +127,7 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                                     <VisualStateGroup x:Name="MinMaxStates">
                                         <VisualState x:Name="WindowStateNormal" />
+                                        <VisualState x:Name="WindowStateTablet" />
 
                                         <VisualState x:Name="WindowStateMaximized">
                                             <VisualState.Setters>

--- a/src/cascadia/TerminalApp/TitlebarControl.idl
+++ b/src/cascadia/TerminalApp/TitlebarControl.idl
@@ -7,7 +7,8 @@ namespace TerminalApp
     {
         WindowVisualStateNormal = 0,
         WindowVisualStateMaximized,
-        WindowVisualStateIconified
+        WindowVisualStateIconified,
+        WindowVisualStateTablet
     };
 
     [default_interface] runtimeclass TitlebarControl : Windows.UI.Xaml.Controls.Grid

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
@@ -22,6 +22,10 @@ Author(s):
 #include "../../types/inc/Viewport.hpp"
 #include <dwmapi.h>
 #include <wil/resource.h>
+#include <windows.ui.viewmanagement.h>
+#include <UIViewSettingsInterop.h>
+#include <wrl/client.h>
+#include <wrl/wrappers/corewrappers.h>
 
 class NonClientIslandWindow : public IslandWindow
 {
@@ -61,6 +65,7 @@ private:
     winrt::Windows::UI::Xaml::ElementTheme _theme;
 
     bool _isMaximized;
+    bool _isTabletMode;
 
     [[nodiscard]] static LRESULT __stdcall _StaticInputSinkWndProc(HWND const window, UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept;
     [[nodiscard]] LRESULT _InputSinkMessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept;
@@ -77,10 +82,13 @@ private:
     [[nodiscard]] LRESULT _OnPaint() noexcept;
     [[nodiscard]] LRESULT _OnSetCursor(WPARAM wParam, LPARAM lParam) const noexcept;
     void _OnMaximizeChange() noexcept;
+    void _OnFullscreenChange() noexcept;
     void _OnDragBarSizeChanged(winrt::Windows::Foundation::IInspectable sender, winrt::Windows::UI::Xaml::SizeChangedEventArgs eventArgs);
 
     void _SetIsFullscreen(const bool fFullscreenEnabled) override;
     bool _IsTitlebarVisible() const;
+
+    void _CheckTabletMode(HWND hwnd) noexcept;
 
     void _UpdateFrameMargins() const noexcept;
     void _UpdateMaximizedState();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Caption buttons support fullscreen and tablet mode
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
https://devblogs.microsoft.com/oldnewthing/?p=93815
https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/move-to-winrt-from-wrl
https://devblogs.microsoft.com/oldnewthing/20170405-00/?p=95905
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2001
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Used [this](https://devblogs.microsoft.com/oldnewthing/?p=93815) to add support for detecting tablet mode


## The PR is a work in progress and the code doesn't work in its current state

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
None
You know how it is, coded on phone, can't get it to compile 😔